### PR TITLE
Fix sort ordering for sequential updates.

### DIFF
--- a/benchmarking.py
+++ b/benchmarking.py
@@ -99,11 +99,11 @@ if __name__ == "__main__":
         msprime.simplify_tables(np.random.choice(2 * args.popsize, args.nsam,
                                                  replace=False).tolist(),
                                 nodes=simplifier.nodes,
-                                edgesets=simplifier.edgesets)
+                                edges=simplifier.edges)
         msp_rng = msprime.RandomGenerator(args.seed)
         sites = msprime.SiteTable()
         mutations = msprime.MutationTable()
         mutgen = msprime.MutationGenerator(
             msp_rng, args.theta / float(4 * args.popsize))
         mutgen.generate(simplifier.nodes,
-                        simplifier.edgesets, sites, mutations)
+                        simplifier.edges, sites, mutations)


### PR DESCRIPTION
We are going forwards in time, but the edge table must be sorted with the most recent edge first. Therefore, we have to sort the newly generated edges and put them at the start of the table.