### PR TITLE
Seed with simulation

### DIFF
--- a/benchmarking.py
+++ b/benchmarking.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     else:
         # Use this module
         simplifier, atracker, tsim = evolve_track(
-            rng, pop, params, args.gc)
+            rng, pop, params, args.gc, True)
         # Take times from simplifier before they change.
         times = simplifier.times
         times['fwd_sim_runtime'] = [tsim]

--- a/fwdpy11_arg_example/ancestry_tracker.hpp
+++ b/fwdpy11_arg_example/ancestry_tracker.hpp
@@ -41,11 +41,11 @@ struct ancestry_tracker
     integer_type generation, next_index, first_parental_index;
     std::uint32_t lastN;
     decltype(node::generation) last_gc_time;
-    ancestry_tracker(const integer_type N, const bool init_with_TreeSequence)
+    ancestry_tracker(const integer_type N, const bool init_with_TreeSequence, const integer_type next_index_)
         : nodes{ std::vector<node>() }, edges{ std::vector<edge>() },
           temp{ std::vector<edge>() },
           offspring_indexes{ std::vector<integer_type>() }, generation{ 1 },
-          next_index{ 2 * N }, first_parental_index{ 0 },
+          next_index{ next_index_ }, first_parental_index{ 0 },
           lastN{ static_cast<std::uint32_t>(N) }, last_gc_time{ 0.0 }
     {
         nodes.reserve(2 * N);
@@ -61,7 +61,6 @@ struct ancestry_tracker
                         nodes.emplace_back(make_node(i, 0.0, 0));
                     }
             }
-        pybind11::print("Node size = ", nodes.size());
     }
 
     std::tuple<integer_type, integer_type>
@@ -117,6 +116,7 @@ struct ancestry_tracker
 
         //convert forward time to backwards time
         auto max_gen = nodes.back().generation;
+
         for (auto& n : nodes)
             {
                 n.generation -= max_gen;

--- a/fwdpy11_arg_example/ancestry_tracker.hpp
+++ b/fwdpy11_arg_example/ancestry_tracker.hpp
@@ -3,10 +3,10 @@
 // gets the data ready to send to msprime
 // and cleanup after msprime simplifies things.
 // The ancestry_tracer is mainly a book-keeper
-// and it is exposed to Python as 
+// and it is exposed to Python as
 // wfarg.AncestryTracker.
-// 
-// This implementation does not have to be 
+//
+// This implementation does not have to be
 // header-only.  However, it is easier (lazier)
 // to do that, and we'll fix that when moving things to
 // fwdpy11.
@@ -41,7 +41,7 @@ struct ancestry_tracker
     integer_type generation, next_index, first_parental_index;
     std::uint32_t lastN;
     decltype(node::generation) last_gc_time;
-    ancestry_tracker(const integer_type N)
+    ancestry_tracker(const integer_type N, const bool init_with_TreeSequence)
         : nodes{ std::vector<node>() }, edges{ std::vector<edge>() },
           temp{ std::vector<edge>() },
           offspring_indexes{ std::vector<integer_type>() }, generation{ 1 },
@@ -53,11 +53,15 @@ struct ancestry_tracker
         temp.reserve(N);
 
         //Initialize 2N nodes for the generation 0
-        for (integer_type i = 0; i < 2 * N; ++i)
+        if (init_with_TreeSequence == false)
             {
-                //ID, time 0, population 0
-                nodes.emplace_back(make_node(i, 0.0, 0));
+                for (integer_type i = 0; i < 2 * N; ++i)
+                    {
+                        //ID, time 0, population 0
+                        nodes.emplace_back(make_node(i, 0.0, 0));
+                    }
             }
+        pybind11::print("Node size = ", nodes.size());
     }
 
     std::tuple<integer_type, integer_type>

--- a/fwdpy11_arg_example/argsimplifier.py
+++ b/fwdpy11_arg_example/argsimplifier.py
@@ -19,8 +19,11 @@ class ArgSimplifier(object):
         self.last_gc_time = 0.0
         self.__nodes = msprime.NodeTable()
         self.__edges = msprime.EdgeTable()
+        self.__process = True
         if trees is not None:
+            self.__process = False
             trees.dump_tables(nodes=self.__nodes, edges=self.__edges)
+            print("input data: ",len(self.__nodes),len(self.__edges))
         self.__time_sorting = 0.0
         self.__time_appending = 0.0
         self.__time_simplifying = 0.0
@@ -28,10 +31,13 @@ class ArgSimplifier(object):
 
     def simplify(self, generation, ancestry):
         # update node times:
-        if self.__nodes.num_rows > 0:
+        if self.__nodes.num_rows > 0: 
+            print("generation = ",generation)
             tc = self.__nodes.time
             dt = float(generation) - self.last_gc_time
+            print(tc)
             tc += dt
+            print("newtimes = ",tc)
             self.last_gc_time = generation
             flags = np.empty([self.__nodes.num_rows], dtype=np.uint32)
             flags.fill(1)
@@ -42,7 +48,12 @@ class ArgSimplifier(object):
         ancestry.prep_for_gc()
         na = np.array(ancestry.nodes, copy=False)
         ea = np.array(ancestry.edges, copy=False)
+        print(na.dtype)
+        print("generations = ",na['generation'])
+        print(na['id'])
+        print(ea)
         samples = np.array(ancestry.samples, copy=False)
+        print(samples)
         flags = np.empty([len(na)], dtype=np.uint32)
         flags.fill(1)
         self.__time_prepping += time.process_time() - before
@@ -89,6 +100,8 @@ class ArgSimplifier(object):
                 nodes=self.__nodes, edges=self.__edges)
         self.__last_edge_start = len(self.__edges)
         self.__time_simplifying += time.process_time() - before
+        self.__process = True
+        print("returning!")
         return (True, self.__nodes.num_rows)
 
     def __call__(self, generation, ancestry):

--- a/fwdpy11_arg_example/argsimplifier.py
+++ b/fwdpy11_arg_example/argsimplifier.py
@@ -23,7 +23,7 @@ class ArgSimplifier(object):
         if trees is not None:
             self.__process = False
             trees.dump_tables(nodes=self.__nodes, edges=self.__edges)
-            print("input data: ",len(self.__nodes),len(self.__edges))
+            # print("input data: ",len(self.__nodes),len(self.__edges))
         self.__time_sorting = 0.0
         self.__time_appending = 0.0
         self.__time_simplifying = 0.0
@@ -32,12 +32,12 @@ class ArgSimplifier(object):
     def simplify(self, generation, ancestry):
         # update node times:
         if self.__nodes.num_rows > 0: 
-            print("generation = ",generation)
+            # print("generation = ",generation)
             tc = self.__nodes.time
             dt = float(generation) - self.last_gc_time
-            print(tc)
+            # print(tc)
             tc += dt
-            print("newtimes = ",tc)
+            # print("newtimes = ",tc)
             self.last_gc_time = generation
             flags = np.empty([self.__nodes.num_rows], dtype=np.uint32)
             flags.fill(1)
@@ -48,17 +48,17 @@ class ArgSimplifier(object):
         ancestry.prep_for_gc()
         na = np.array(ancestry.nodes, copy=False)
         ea = np.array(ancestry.edges, copy=False)
-        print(na.dtype)
-        print("generations = ",na['generation'])
-        print(na['id'])
-        print(ea)
+        # print(na.dtype)
+        # print("generations = ",na['generation'])
+        # print(na['id'])
         samples = np.array(ancestry.samples, copy=False)
-        print(samples)
+        # print(samples)
         flags = np.empty([len(na)], dtype=np.uint32)
         flags.fill(1)
         self.__time_prepping += time.process_time() - before
 
         before = time.process_time()
+        clen = len(self.__nodes)
         self.__nodes.append_columns(flags=flags,
                                     population=na['population'],
                                     time=na['generation'])
@@ -101,7 +101,7 @@ class ArgSimplifier(object):
         self.__last_edge_start = len(self.__edges)
         self.__time_simplifying += time.process_time() - before
         self.__process = True
-        print("returning!")
+        # print("returning!")
         return (True, self.__nodes.num_rows)
 
     def __call__(self, generation, ancestry):

--- a/fwdpy11_arg_example/argsimplifier.py
+++ b/fwdpy11_arg_example/argsimplifier.py
@@ -10,14 +10,17 @@ class ArgSimplifier(object):
     AncestryTracker and msprime
     """
 
-    def __init__(self, gc_interval):
+    def __init__(self, gc_interval, trees = None):
         """
         :param gc_interval: Garbage collection interval
+        :param trees: An instance of :class:`msprime.TreeSequence`
         """
         self.gc_interval = gc_interval
         self.last_gc_time = 0.0
         self.__nodes = msprime.NodeTable()
         self.__edges = msprime.EdgeTable()
+        if trees is not None:
+            trees.dump_tables(nodes=self.__nodes, edges=self.__edges)
         self.__time_sorting = 0.0
         self.__time_appending = 0.0
         self.__time_simplifying = 0.0

--- a/fwdpy11_arg_example/evolve_arg.py
+++ b/fwdpy11_arg_example/evolve_arg.py
@@ -43,11 +43,13 @@ def evolve_track(rng, pop, params, gc_interval, init_with_TreeSequence=False):
     from .wfarg import evolve_singlepop_regions_track_ancestry, AncestryTracker
     from .argsimplifier import ArgSimplifier
     initial_TreeSequence = None
+    next_index = 2*pop.N
     if init_with_TreeSequence is True:
         initial_TreeSequence = msprime.simulate(
             2 * pop.N, recombination_rate=params.recrate / 2.0, Ne=pop.N)
+        next_index = initial_TreeSequence.num_nodes
     simplifier = ArgSimplifier(gc_interval, initial_TreeSequence)
-    atracker = AncestryTracker(pop.N, init_with_TreeSequence)
+    atracker = AncestryTracker(pop.N, init_with_TreeSequence, next_index)
     tsim = evolve_singlepop_regions_track_ancestry(rng, pop, atracker, simplifier,
                                                    params.demography,
                                                    params.mutrate_s,

--- a/fwdpy11_arg_example/evolve_arg.py
+++ b/fwdpy11_arg_example/evolve_arg.py
@@ -5,7 +5,7 @@ import numpy as np
 import msprime
 
 
-def evolve_track(rng, pop, params, gc_interval, init_with_TreeSequence=False):
+def evolve_track(rng, pop, params, gc_interval, init_with_TreeSequence=False, msprime_seed=None):
     """
     Evolve a population and track its ancestry using msprime.
 
@@ -45,8 +45,11 @@ def evolve_track(rng, pop, params, gc_interval, init_with_TreeSequence=False):
     initial_TreeSequence = None
     next_index = 2*pop.N
     if init_with_TreeSequence is True:
+        if msprime_seed is None: 
+            import warnings
+            warnings.warn("msprime_seed is None. Results will not be reprodicible.")
         initial_TreeSequence = msprime.simulate(
-            2 * pop.N, recombination_rate=params.recrate / 2.0, Ne=pop.N)
+            2 * pop.N, recombination_rate=params.recrate / 2.0, Ne=pop.N, random_seed=msprime_seed)
         next_index = initial_TreeSequence.num_nodes
     simplifier = ArgSimplifier(gc_interval, initial_TreeSequence)
     atracker = AncestryTracker(pop.N, init_with_TreeSequence, next_index)

--- a/fwdpy11_arg_example/evolve_arg.py
+++ b/fwdpy11_arg_example/evolve_arg.py
@@ -43,11 +43,12 @@ def evolve_track(rng, pop, params, gc_interval, init_with_TreeSequence=False, ms
     from .wfarg import evolve_singlepop_regions_track_ancestry, AncestryTracker
     from .argsimplifier import ArgSimplifier
     initial_TreeSequence = None
-    next_index = 2*pop.N
+    next_index = 2 * pop.N
     if init_with_TreeSequence is True:
-        if msprime_seed is None: 
+        if msprime_seed is None:
             import warnings
-            warnings.warn("msprime_seed is None. Results will not be reprodicible.")
+            warnings.warn(
+                "msprime_seed is None. Results will not be reprodicible.")
         initial_TreeSequence = msprime.simulate(
             2 * pop.N, recombination_rate=params.recrate / 2.0, Ne=pop.N, random_seed=msprime_seed)
         next_index = initial_TreeSequence.num_nodes

--- a/fwdpy11_arg_example/evolve_arg.py
+++ b/fwdpy11_arg_example/evolve_arg.py
@@ -47,7 +47,7 @@ def evolve_track(rng, pop, params, gc_interval, init_with_TreeSequence=False):
         initial_TreeSequence = msprime.simulate(
             2 * pop.N, recombination_rate=params.recrate / 2.0, Ne=pop.N)
     simplifier = ArgSimplifier(gc_interval, initial_TreeSequence)
-    atracker = AncestryTracker(pop.N)
+    atracker = AncestryTracker(pop.N, init_with_TreeSequence)
     tsim = evolve_singlepop_regions_track_ancestry(rng, pop, atracker, simplifier,
                                                    params.demography,
                                                    params.mutrate_s,

--- a/fwdpy11_arg_example/evolve_arg.py
+++ b/fwdpy11_arg_example/evolve_arg.py
@@ -5,7 +5,7 @@ import numpy as np
 import msprime
 
 
-def evolve_track(rng, pop, params, gc_interval):
+def evolve_track(rng, pop, params, gc_interval, init_with_TreeSequence=False):
     """
     Evolve a population and track its ancestry using msprime.
 
@@ -42,7 +42,11 @@ def evolve_track(rng, pop, params, gc_interval):
 
     from .wfarg import evolve_singlepop_regions_track_ancestry, AncestryTracker
     from .argsimplifier import ArgSimplifier
-    simplifier = ArgSimplifier(gc_interval)
+    initial_TreeSequence = None
+    if init_with_TreeSequence is True:
+        initial_TreeSequence = msprime.simulate(
+            2 * pop.N, recombination_rate=params.recrate / 2.0, Ne=pop.N)
+    simplifier = ArgSimplifier(gc_interval, initial_TreeSequence)
     atracker = AncestryTracker(pop.N)
     tsim = evolve_singlepop_regions_track_ancestry(rng, pop, atracker, simplifier,
                                                    params.demography,

--- a/fwdpy11_arg_example/evolve_generation.hpp
+++ b/fwdpy11_arg_example/evolve_generation.hpp
@@ -75,7 +75,6 @@ evolve_generation(const fwdpy11::GSLrng_t& rng, poptype& pop,
                                         pop.mutations);
             auto pid = ancestry.get_parent_ids(p1, swap1);
             auto offspring_indexes = ancestry.get_next_indexes();
-
             dip.first = ancestry_recombination_details(
                 pop, ancestry, gamete_recycling_bin, p1g1, p1g2, breakpoints,
                 pid, std::get<0>(offspring_indexes));

--- a/fwdpy11_arg_example/wfarg.cc
+++ b/fwdpy11_arg_example/wfarg.cc
@@ -108,7 +108,7 @@ evolve_singlepop_regions_track_ancestry(
             fitness.update(pop);
             wbar = rules.w(pop, fitness_callback);
             auto stop = std::clock();
-            auto dur = (stop - start) / (double) CLOCKS_PER_SEC;
+            auto dur = (stop - start) / (double)CLOCKS_PER_SEC;
             time_simulating += dur;
         }
     --pop.generation;
@@ -122,7 +122,8 @@ PYBIND11_MAKE_OPAQUE(std::vector<ancestry_tracker::integer_type>);
 
 PYBIND11_MODULE(wfarg, m)
 {
-    m.doc() = "Simple example of Wright-Fisher simulation with selection and ARG tracking";
+    m.doc() = "Simple example of Wright-Fisher simulation with selection and "
+              "ARG tracking";
 
     //Register nodes and edges as NumPy dtypes:
     PYBIND11_NUMPY_DTYPE(node, id, population, generation);
@@ -151,7 +152,9 @@ PYBIND11_MODULE(wfarg, m)
     //We only expose the stuff that a user really needs
     //to see.
     py::class_<ancestry_tracker>(m, "AncestryTracker")
-        .def(py::init<decltype(edge::parent),bool>(), py::arg("N"),py::arg("init_with_TreeSequence"))
+        .def(py::init<decltype(edge::parent), bool, decltype(edge::parent)>(),
+             py::arg("N"), py::arg("init_with_TreeSequence"),
+             py::arg("next_index"))
         .def_readwrite("nodes", &ancestry_tracker::nodes,
                        "Data for msprime.NodeTable.")
         .def_readwrite("edges", &ancestry_tracker::edges,

--- a/fwdpy11_arg_example/wfarg.cc
+++ b/fwdpy11_arg_example/wfarg.cc
@@ -151,7 +151,7 @@ PYBIND11_MODULE(wfarg, m)
     //We only expose the stuff that a user really needs
     //to see.
     py::class_<ancestry_tracker>(m, "AncestryTracker")
-        .def(py::init<decltype(edge::parent)>(), py::arg("N"))
+        .def(py::init<decltype(edge::parent),bool>(), py::arg("N"),py::arg("init_with_TreeSequence"))
         .def_readwrite("nodes", &ancestry_tracker::nodes,
                        "Data for msprime.NodeTable.")
         .def_readwrite("edges", &ancestry_tracker::edges,


### PR DESCRIPTION
This PR add the ability to start a simulation with a TreeSequence from msprime.

The general idea is:

1. If doing this, do not initialize 2N nodes on the C++ side.
2. If doing this, take the Node/Edge tables from the TreeSequence and store them in the ArgSimplifier.

The current challenge is that there is a sorting problem.  For example, this command will exit with an error:

```
python benchmarking.py --popsize 1000 -T 100 -R 100 --pdel 0 --nsam 10 -G 1000 --outfile1 foo --simlen 10 -S 10
```
Pinging @jeromekelleher for advice.