### PR TITLE
Fix race condition

### DIFF
--- a/fwdpy11_arg_example/ancestry_tracker.hpp
+++ b/fwdpy11_arg_example/ancestry_tracker.hpp
@@ -33,7 +33,7 @@ class spinlock
     std::atomic_flag f;
 
   public:
-    spinlock() : f(ATOMIC_FLAG_INIT) {}
+    spinlock() : f{ ATOMIC_FLAG_INIT } {}
     void
     lock()
     {
@@ -98,12 +98,12 @@ struct ancestry_tracker
           next_index{ a.next_index },
           first_parental_index{ a.first_parental_index }, lastN{ a.lastN },
           last_gc_time{ a.last_gc_time }, ready{}
-	// Copy construtor.
-	// This only exists so that we can wrap this object
-	// in a shared_ptr in a pybind11::class_.  This
-	// constructor must NOT be exposed to Python via 
-	// pybind11::init<>.  Any use other than initialization
-	// into a shared_ptr is considered undefined behavior.
+    // Copy construtor.
+    // This only exists so that we can wrap this object
+    // in a shared_ptr in a pybind11::class_.  This
+    // constructor must NOT be exposed to Python via
+    // pybind11::init<>.  Any use other than initialization
+    // into a shared_ptr is considered undefined behavior.
     {
     }
 
@@ -189,7 +189,9 @@ struct ancestry_tracker
     void
     exchange_for_async(ancestry_tracker& a)
     {
+        pybind11::print("getting lock...");
         a.ready.lock();
+        pybind11::print("got lock...");
         nodes.swap(a.nodes);
         edges.swap(a.edges);
         a.offspring_indexes.assign(offspring_indexes.begin(),
@@ -197,6 +199,7 @@ struct ancestry_tracker
         nodes.clear();
         edges.clear();
         first_parental_index = 0;
+        pybind11::print("returning from exchange_for_async");
     }
     void
     update_indexes(const integer_type delta, const integer_type mindex,
@@ -217,7 +220,9 @@ struct ancestry_tracker
     void
     release_spinlock()
     {
+        pybind11::print("releasing...");
         ready.unlock();
+        pybind11::print("returning from release...");
     }
 };
 

--- a/fwdpy11_arg_example/argsimplifier.py
+++ b/fwdpy11_arg_example/argsimplifier.py
@@ -10,7 +10,10 @@ class ArgSimplifier(object):
     AncestryTracker and msprime
     """
 
-    def __init__(self, gc_interval, trees = None):
+    from .wfarg import reverse_time
+    from .wfarg import update_indexes
+
+    def __init__(self, gc_interval, trees=None):
         """
         :param gc_interval: Garbage collection interval
         :param trees: An instance of :class:`msprime.TreeSequence`
@@ -29,8 +32,9 @@ class ArgSimplifier(object):
         self.__time_prepping = 0.0
 
     def simplify(self, generation, ancestry):
+        print(type(ancestry))
         # update node times:
-        if self.__nodes.num_rows > 0: 
+        if self.__nodes.num_rows > 0:
             tc = self.__nodes.time
             dt = float(generation) - self.last_gc_time
             tc += dt
@@ -40,15 +44,16 @@ class ArgSimplifier(object):
                 flags=flags, population=self.__nodes.population, time=tc)
 
         before = time.process_time()
-        ancestry.prep_for_gc()
+        self.reverse_time(ancestry.nodes)
+        # ancestry.prep_for_gc()
         na = np.array(ancestry.nodes, copy=False)
         ea = np.array(ancestry.edges, copy=False)
         new_min_id = na['id'][0]
         new_max_id = na['id'][-1]
         delta = new_min_id - len(self.__nodes)
-        samples = np.array(ancestry.samples, copy=False)
         if delta != 0:
-            ancestry.update_indexes(delta,new_min_id,new_max_id);
+            self.update_indexes(ancestry.edges,ancestry.samples,delta, new_min_id, new_max_id)
+        samples = np.array(ancestry.samples, copy=False)
         flags = np.ones(len(na), dtype=np.uint32)
         self.__time_prepping += time.process_time() - before
 
@@ -90,12 +95,15 @@ class ArgSimplifier(object):
         self.__time_sorting += time.process_time() - before
 
         # Append the old sorted edges to the table.
-        self.__edges.append_columns(left=left, right=right, parent=parent, child=child)
+        self.__edges.append_columns(
+            left=left, right=right, parent=parent, child=child)
         # We can now release the mutex
-        ancestry.release_spinlock()
+        print("release lock...")
+        # ancestry.release_spinlock()
+        print("done releasing lock in Py side")
         before = time.process_time()
         msprime.simplify_tables(samples=samples.tolist(),
-                nodes=self.__nodes, edges=self.__edges)
+                                nodes=self.__nodes, edges=self.__edges)
         self.__last_edge_start = len(self.__edges)
         self.__time_simplifying += time.process_time() - before
         self.__process = True

--- a/fwdpy11_arg_example/evolve_arg.py
+++ b/fwdpy11_arg_example/evolve_arg.py
@@ -75,7 +75,7 @@ def evolve_track(rng, pop, params, gc_interval, init_with_TreeSequence=False, ms
     else:
         import threading
         import queue
-        q = queue.Queue(4)
+        q = queue.Queue(qsize)
 
         def worker():
             while True:

--- a/fwdpy11_arg_example/wfarg.cc
+++ b/fwdpy11_arg_example/wfarg.cc
@@ -91,6 +91,8 @@ PYBIND11_MODULE(wfarg, m)
           &evolve_singlepop_regions_track_ancestry_async);
     m.def("evolve_singlepop_regions_track_ancestry_python_queue",
           &evolve_singlepop_regions_track_ancestry_python_queue);
-    m.def("reverse_time", &reverse_time);
-    m.def("update_indexes", &update_indexes);
+    m.def("reverse_time", &reverse_time,
+          py::call_guard<py::gil_scoped_release>());
+    m.def("update_indexes", &update_indexes,
+          py::call_guard<py::gil_scoped_release>());
 }

--- a/fwdpy11_arg_example/wfarg.cc
+++ b/fwdpy11_arg_example/wfarg.cc
@@ -60,22 +60,26 @@ PYBIND11_MODULE(wfarg, m)
             "Read-only access to current offspring/children generation.")
         .def_readonly("last_gc_time", &ancestry_tracker::last_gc_time,
                       "Last time point where garbage collection happened.")
-        //.def("update_indexes", &ancestry_tracker::update_indexes)
-        //.def("prep_for_gc", &ancestry_tracker::prep_for_gc,
-        //     "Call this immediately before you are going to simplify.")
-        .def("release_spinlock", &ancestry_tracker::release_spinlock,
-             "Releases the spin lock.  Used in multi-threaded applications of "
-             "the msprime machinery.");
+        .def("release", [](ancestry_tracker& a) {})
+        .def("acquire", [](ancestry_tracker& a) {});
+    //.def("update_indexes", &ancestry_tracker::update_indexes)
+    //.def("prep_for_gc", &ancestry_tracker::prep_for_gc,
+    //     "Call this immediately before you are going to simplify.")
+    //.def("release_spinlock", &ancestry_tracker::release_spinlock,
+    //     "Releases the spin lock.  Used in multi-threaded applications of "
+    //     "the msprime machinery.");
 
-    py::class_<ancestry_data>(m, "_AncestryData",
-			"Used internally for data-swapping in multi-threaded scenarios")
+    py::class_<ancestry_data>(
+        m, "_AncestryData",
+        "Used internally for data-swapping in multi-threaded scenarios")
         .def(py::init<>())
         .def_readwrite("nodes", &ancestry_data::nodes,
                        "Data for msprime.NodeTable.")
         .def_readwrite("edges", &ancestry_data::edges,
                        "Data for msprime.EdgesetTable.")
-        .def_readwrite("samples", &ancestry_data::samples,
-                       "Sample indexes.");
+        .def_readwrite("samples", &ancestry_data::samples, "Sample indexes.")
+        .def("release", [](ancestry_data& a) { a.lock_.attr("release")(); })
+        .def("acquire", [](ancestry_data& a) { a.lock_.attr("acquire")(); });
 
     //Make our C++ functions callable from Python.
     //This is NOT part of a user-facing Python API.
@@ -87,6 +91,6 @@ PYBIND11_MODULE(wfarg, m)
           &evolve_singlepop_regions_track_ancestry_async);
     m.def("evolve_singlepop_regions_track_ancestry_python_queue",
           &evolve_singlepop_regions_track_ancestry_python_queue);
-	m.def("reverse_time",&reverse_time);
-	m.def("update_indexes",&update_indexes);
+    m.def("reverse_time", &reverse_time);
+    m.def("update_indexes", &update_indexes);
 }

--- a/fwdpy11_arg_example/wfarg.cc
+++ b/fwdpy11_arg_example/wfarg.cc
@@ -44,11 +44,11 @@ PYBIND11_MODULE(wfarg, m)
     //Expose the C++ ancestry_tracker to Python.
     //We only expose the stuff that a user really needs
     //to see.
-    py::class_<ancestry_tracker,std::shared_ptr<ancestry_tracker>>(m, "AncestryTracker")
+    py::class_<ancestry_tracker>(m, "AncestryTracker")
         .def(py::init<decltype(edge::parent), bool, decltype(edge::parent)>(),
              py::arg("N"), py::arg("init_with_TreeSequence"),
              py::arg("next_index"))
-		.def(py::init<ancestry_tracker&>())
+        .def(py::init<ancestry_tracker&>())
         .def_readwrite("nodes", &ancestry_tracker::nodes,
                        "Data for msprime.NodeTable.")
         .def_readwrite("edges", &ancestry_tracker::edges,
@@ -60,14 +60,24 @@ PYBIND11_MODULE(wfarg, m)
             "Read-only access to current offspring/children generation.")
         .def_readonly("last_gc_time", &ancestry_tracker::last_gc_time,
                       "Last time point where garbage collection happened.")
-        .def("update_indexes", &ancestry_tracker::update_indexes)
-        .def("prep_for_gc", &ancestry_tracker::prep_for_gc,
-             "Call this immediately before you are going to simplify.")
+        //.def("update_indexes", &ancestry_tracker::update_indexes)
+        //.def("prep_for_gc", &ancestry_tracker::prep_for_gc,
+        //     "Call this immediately before you are going to simplify.")
         .def("release_spinlock", &ancestry_tracker::release_spinlock,
              "Releases the spin lock.  Used in multi-threaded applications of "
              "the msprime machinery.");
 
-    //Make our C++ function callable from Python.
+    py::class_<ancestry_data>(m, "_AncestryData",
+			"Used internally for data-swapping in multi-threaded scenarios")
+        .def(py::init<>())
+        .def_readwrite("nodes", &ancestry_data::nodes,
+                       "Data for msprime.NodeTable.")
+        .def_readwrite("edges", &ancestry_data::edges,
+                       "Data for msprime.EdgesetTable.")
+        .def_readwrite("samples", &ancestry_data::samples,
+                       "Sample indexes.");
+
+    //Make our C++ functions callable from Python.
     //This is NOT part of a user-facing Python API.
     //Rather, we need a wrapper to integrate it with
     //the rest of the fwdpy11 world.
@@ -77,4 +87,6 @@ PYBIND11_MODULE(wfarg, m)
           &evolve_singlepop_regions_track_ancestry_async);
     m.def("evolve_singlepop_regions_track_ancestry_python_queue",
           &evolve_singlepop_regions_track_ancestry_python_queue);
+	m.def("reverse_time",&reverse_time);
+	m.def("update_indexes",&update_indexes);
 }

--- a/fwdpy11_arg_example/wright_fisher_async.cc
+++ b/fwdpy11_arg_example/wright_fisher_async.cc
@@ -56,7 +56,7 @@ evolve_singlepop_regions_track_ancestry_async(
     auto wbar = rules.w(pop, fitness_callback);
 
     std::future<py::object> msprime_future;
-    ancestry_tracker local_ancestry_tracker;
+    ancestry_data local_ancestry_data;
     double time_simulating = 0.0;
     for (unsigned generation = 0; generation < generations;
          ++generation, ++pop.generation)
@@ -71,10 +71,10 @@ evolve_singlepop_regions_track_ancestry_async(
                             ancestry.post_process_gc(result_tuple, false);
                         }
 
-                    ancestry.exchange_for_async(local_ancestry_tracker);
+                    ancestry.exchange_for_async(local_ancestry_data);
                     msprime_future = std::async(
                         std::launch::async, ancestry_processor, pop.generation,
-                        std::ref(local_ancestry_tracker));
+                        std::ref(local_ancestry_data));
                 }
             //This is not great API design, but
             //we need to clear the offspring indexes here:

--- a/fwdpy11_arg_example/wright_fisher_queue.cc
+++ b/fwdpy11_arg_example/wright_fisher_queue.cc
@@ -64,7 +64,7 @@ evolve_singlepop_regions_track_ancestry_python_queue(
     std::vector<py::object> faux_memory_pool(python_qsize);
     for (auto& i : faux_memory_pool)
         {
-            i = py::cast(ancestry_tracker());
+            i = py::cast(ancestry_data());
         }
     std::size_t items_submitted = 0;
     for (unsigned generation = 0; generation < generations;
@@ -77,7 +77,7 @@ evolve_singlepop_regions_track_ancestry_python_queue(
 						py::print("exchanging at gen",pop.generation);
                         ancestry.exchange_for_async(
                             faux_memory_pool[items_submitted]
-                                .cast<ancestry_tracker&>());
+                                .cast<ancestry_data&>());
 						py::print("putting...");
                         python_queue.attr("put")(py::make_tuple(
                             pop.generation,

--- a/fwdpy11_arg_example/wright_fisher_queue.cc
+++ b/fwdpy11_arg_example/wright_fisher_queue.cc
@@ -74,12 +74,15 @@ evolve_singlepop_regions_track_ancestry_python_queue(
                 {
                     {
                         py::gil_scoped_acquire acquire;
+						py::print("exchanging at gen",pop.generation);
                         ancestry.exchange_for_async(
                             faux_memory_pool[items_submitted]
                                 .cast<ancestry_tracker&>());
+						py::print("putting...");
                         python_queue.attr("put")(py::make_tuple(
                             pop.generation,
                             faux_memory_pool[items_submitted++]));
+						py::print("done putting");
                     }
                     if (items_submitted >= python_qsize)
                         {


### PR DESCRIPTION
This PR fixes a data race in the code path using threading.Thread/queue.Queue.  The original implementation was quite naive in how the "faux memory pool" was used.  C++11 synchronization types do not solve the problem, and they create a headache w.r.to having "nice" Python types via pybind11.  The solution is to be more Pythonic, and use threading.Lock to synchronize between the C++ side and the Python/msprime side.